### PR TITLE
fix(signup): 이메일 중복 확인 시 금지된 이메일과 DB 중복 이메일 구분

### DIFF
--- a/src/config/supabase.js
+++ b/src/config/supabase.js
@@ -115,7 +115,7 @@ export const authAPI = {
       const forbiddenEmails = ['admin@test.com', 'test@example.com']
       if (forbiddenEmails.includes(email.toLowerCase())) {
         return {
-          data: { exists: true },
+          data: { exists: true, forbidden: true },
           error: null
         }
       }

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -426,7 +426,11 @@ export default {
           this.errors.email = "이메일 확인 중 오류가 발생했습니다"
           this.emailAvailable = false
         } else if (data.exists) {
-          this.errors.email = "이미 가입된 이메일입니다"
+          if (data.forbidden) {
+            this.errors.email = "사용할 수 없는 이메일입니다"
+          } else {
+            this.errors.email = "이미 가입된 이메일입니다"
+          }
           this.emailAvailable = false
         } else {
           this.errors.email = ""


### PR DESCRIPTION
- 금지된 이메일: "사용할 수 없는 이메일입니다" 메시지 표시
- DB 중복 이메일: "이미 가입된 이메일입니다" 메시지 표시
- supabase.js에서 금지된 이메일 응답에 forbidden 플래그 추가
- Signup.vue에서 forbidden 플래그에 따른 메시지 분기 처리

🤖 Generated with [Claude Code](https://claude.ai/code)