### PR TITLE
fix(auth): 새로고침 시 자동 로그아웃 문제 해결

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,16 +62,8 @@ export default {
           return;
         }
         
-        const shouldRemember = localStorage.getItem('rememberUser') === 'true';
-        if (!shouldRemember) {
-          // '상태 유지'가 아니면 즉시 로그아웃 처리
-          console.log('상태 유지 안함, 자동 로그아웃')
-          supabase.auth.signOut();
-        } else {
-          // '상태 유지'인 경우, 사용자 정보를 설정
-          console.log('상태 유지 모드, 사용자 세션 설정')
-          this.setUser(session);
-        }
+        // 세션이 있으면 바로 사용자 설정 (강제 로그아웃 로직 제거)
+        this.setUser(session);
       }
     });
 

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -140,8 +140,8 @@ export default {
           localStorage.setItem('rememberUser', 'true')
           localStorage.setItem('userEmail', this.email)
         } else {
-          localStorage.setItem('rememberUser', 'false')
-          localStorage.removeItem('userEmail')
+          localStorage.setItem('rememberUser', 'true')  // ✅ 기본적으로 세션 유지
+          localStorage.removeItem('userEmail')  // 이메일만 기억 안함
         }
 
         // Supabase로 로그인 시도


### PR DESCRIPTION
- App.vue에서 강제 로그아웃 로직 제거
  - shouldRemember 체크 조건문 삭제
  - 세션이 존재하면 바로 사용자 설정하도록 변경
  - Supabase의 기본 persistSession 동작 활용

- Login.vue에서 세션 유지 기본값 변경
  - 로그인 상태 유지 체크 안해도 세션 유지
  - 이메일 기억 기능만 선택적으로 동작

이제 사용자가 명시적으로 로그아웃 버튼을 누르기 전까지는
새로고침(F5)을 해도 로그인 상태가 유지됩니다.